### PR TITLE
Treat Symbol cache keys as strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,8 @@ function stringifyValue(value, key) {
 // This is basically a home-grown JSON.stringifier. However, JSON.stringify on objects
 // depends on the order in which the properties were defined - which we don't like!
 // Additionally, JSON.stringify escapes strings, which we don't need here
-function stringifyObject(object, keys = Object.keys(object)) {
-  return keys.sort().map(key => `${key}:${stringifyValue(object[key], key)}`).join('|');
+function stringifyObject(object, keys = [...Object.keys(object), ...Object.getOwnPropertySymbols(object)]) {
+  return keys.sort().map(key => `${key.toString()}:${stringifyValue(object[key], key)}`).join('|');
 }
 
 export function getCacheKey(model, attribute, options) {

--- a/test/unit/getCacheKey.test.js
+++ b/test/unit/getCacheKey.test.js
@@ -74,6 +74,18 @@ describe('getCacheKey', function () {
         'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|through:undefined|where:completed:true');
     });
 
+    it('symbols', function () {
+      const or = new Symbol('or');
+      expect(getCacheKey(User, 'id', {
+        where: {
+          [Symbol('or')]: {
+            name: { [Symbol('iLike')] : '%test%' }
+          }
+        }
+      }), 'to equal',
+        'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|through:undefined|where:Symbol(or):name:Symbol(iLike):%test%');
+    })
+
     it('date', function () {
       const from = new Date(Date.UTC(2016, 1, 1));
       const to = new Date(Date.UTC(2016, 2, 1));

--- a/test/unit/getCacheKey.test.js
+++ b/test/unit/getCacheKey.test.js
@@ -75,16 +75,15 @@ describe('getCacheKey', function () {
     });
 
     it('symbols', function () {
-      const or = new Symbol('or');
       expect(getCacheKey(User, 'id', {
         where: {
           [Symbol('or')]: {
-            name: { [Symbol('iLike')] : '%test%' }
+            name: { [Symbol('iLike')]: '%test%' }
           }
         }
       }), 'to equal',
         'user|id|association:undefined|attributes:undefined|groupedLimit:undefined|limit:undefined|offset:undefined|order:undefined|raw:undefined|through:undefined|where:Symbol(or):name:Symbol(iLike):%test%');
-    })
+    });
 
     it('date', function () {
       const from = new Date(Date.UTC(2016, 1, 1));


### PR DESCRIPTION
Addresses https://github.com/mickhansen/dataloader-sequelize/issues/42 by treating all cache keys as strings and using Object.getOwnPropertySymbols to reference.